### PR TITLE
Bugfix

### DIFF
--- a/Enclave/Enclave.edl
+++ b/Enclave/Enclave.edl
@@ -18,7 +18,7 @@ enclave {
                              [in, string]const char* request_id, 
                              [in, size=data_len]const char* input_data,
                              uint64_t data_len,
-                             [user_check] char **output, 
+                             [out]  char **output,
                              [out] uint64_t *output_len);
 
         /**
@@ -29,7 +29,7 @@ enclave {
         /**
          *  To return this enclave id in hex string
          */
-        public int ecall_get_enclave_id([user_check] char **output, [out] uint64_t *output_len);
+        public int ecall_get_enclave_id([out] char **output, [out] uint64_t *output_len);
 
         /**
          *  To set a status to the key shard generation task
@@ -67,7 +67,7 @@ enclave {
         /*
         *  free a buffer in the untrusted memory, which is malloc in untrusted code
         */
-        void ocall_free( [user_check] uint8_t* p_out_side );
+        void ocall_free( [in] uint8_t* p_out_side );
     };
 
 };

--- a/Enclave/common/tee_util.cpp
+++ b/Enclave/common/tee_util.cpp
@@ -92,7 +92,6 @@ uint8_t* malloc_outside( size_t size )
     if (!outside_buf) {
         return nullptr;
     }
-    memset(outside_buf, 0, size);
 
     //check buff is outside or not
     if ( sgx_is_outside_enclave(outside_buf, size) != 1 ) {
@@ -100,6 +99,7 @@ uint8_t* malloc_outside( size_t size )
         outside_buf = nullptr;
         return nullptr;
     }
+    memset(outside_buf, 0, size);
 
     sgx_lfence();
 


### PR DESCRIPTION
Prevents a local attacker from overwriting arbitrary enclave memory in an untrusted environment when the attacker gains root privileges of host.